### PR TITLE
Fix typos and 404's

### DIFF
--- a/12-kernel-c/README.md
+++ b/12-kernel-c/README.md
@@ -37,7 +37,7 @@ generates machine code without any labels and/or metadata
 
 *Note: a warning may appear when linking, disregard it*
 
-Now examine both "binary" files, `function.o` and `function.bin` using `xdd`. You
+Now examine both "binary" files, `function.o` and `function.bin` using `xxd`. You
 will see that the `.bin` file is machine code, while the `.o` file has a lot
 of debugging information, labels, etc.
 

--- a/14-checkpoint/README.md
+++ b/14-checkpoint/README.md
@@ -20,7 +20,7 @@ on Homebrew's repos)
 
 ```sh
 cd /tmp/src
-curl -O http://ftp.rediris.es/mirror/GNU/gnu/gdb/gdb-7.8.tar.gz
+curl -O http://ftp.rediris.es/mirror/GNU/gdb/gdb-7.8.tar.gz
 tar xf gdb-7.8.tar.gz
 mkdir gdb-build
 cd gdb-build


### PR DESCRIPTION
In 12-kernel-c/README.md `xdd` should be `xxd`

**Edit 1:**
In 14-checkpoint/README.md `curl -O http://ftp.rediris.es/mirror/GNU/gnu/gdb/gdb-7.8.tar.gz` should be `curl -O http://ftp.rediris.es/mirror/GNU/gdb/gdb-7.8.tar.gz`. The original URL returns a 404. This was originally pointed out by @raibu in Issue #37.