### PR TITLE
adding _start to kernel_entry.asm

### DIFF
--- a/13-kernel-barebones/kernel_entry.asm
+++ b/13-kernel-barebones/kernel_entry.asm
@@ -1,4 +1,7 @@
+global _start;
 [bits 32]
-[extern main] ; Define calling point. Must have same name as kernel.c 'main' function
-call main ; Calls the C function. The linker will know where it is placed in memory
-jmp $
+
+_start:
+    [extern main] ; Define calling point. Must have same name as kernel.c 'main' function
+    call main ; Calls the C function. The linker will know where it is placed in memory
+    jmp $


### PR DESCRIPTION
When running this command:

```
$ i386-elf-ld -o /rootfs/boot/kernel.bin -Ttext 0x1000 /code/kernel/kernel_entry.o /code/kernel/kernel.o --oformat binary
```
I got an error about the `_start` missing

```
i386-elf-ld: warning: cannot find entry symbol _start; defaulting to 0000000000001000
```
And the fix was to add it (see PR). I'm testing the build from scratch to see if there are any new issues that arise, but at least in basic testing this seemed ok to me! I'm very new at assembly / C so apologies in advance if I am missing something!