### PR TITLE
Fixed assembler error

### DIFF
--- a/05-bootsector-functions-strings/boot_sect_print_hex.asm
+++ b/05-bootsector-functions-strings/boot_sect_print_hex.asm
@@ -37,7 +37,7 @@ end:
     ; prepare the parameter and call the function
     ; remember that print receives parameters in 'bx'
     mov bx, HEX_OUT
-    call print
+    call print_hex
 
     popa
     ret


### PR DESCRIPTION
Fixed assembler error in 05-bootsector-functions-strings/boot_sect_print_hex.asm would not find print on line 40.

Previously users would get this error:

    boot_sect_print_hex.asm:40: error: symbol `print' undefined