### PR TITLE
Stack Access Misinterpretation

### DIFF
--- a/04-bootsector-stack/boot_sect_stack.asm
+++ b/04-bootsector-stack/boot_sect_stack.asm
@@ -1,19 +1,23 @@
 mov ah, 0x0e ; tty mode
 
-mov bp, 0x8000 ; this is an address far away from 0x7c00 so that we don't get overwritten
-mov sp, bp ; if the stack is empty then sp points to bp
+mov bp, 0x8000 	; this is an address far away from 0x7c00 so that we don't get overwritten
+mov sp, bp 	; if the stack is empty then sp points to bp
+; if we push (0x8000 - 0x7c00) bits (0x400 or 1,024 bits), we will start to write over
+; the bootloader. so, don't do that! 
 
+; still in 16-bit mode, so these each push 16 bits onto the stack. 
 push 'A'
 push 'B'
 push 'C'
 
 ; to show how the stack grows downwards
-mov al, [0x7ffe] ; 0x8000 - 2
+mov al, [0x7ffe] ; 0x8000 - 16 bits
 int 0x10
 
-; however, don't try to access [0x8000] now, because it won't work
-; you can only access the stack top so, at this point, only 0x7ffe (look above)
-mov al, [0x8000]
+mov al, [0x8000] ; this is a null byte - it's the top of the stack
+int 0x10
+
+mov al, [0x7ffa] ; 0x8000 - 48 bits. lower in memory
 int 0x10
 
 


### PR DESCRIPTION
There's a comment in here that's not quite right. We *can* access different parts of the stack, but this example wasn't pointing to a different part of the stack.

This updated code shows that we can access different parts of the stack, and explains why. 