### PR TITLE
Fixed hex_to_string to display 'a' character properly.

### DIFF
--- a/22-malloc/libc/string.c
+++ b/22-malloc/libc/string.c
@@ -29,7 +29,7 @@ void hex_to_ascii(int n, char str[]) {
         tmp = (n >> i) & 0xF;
         if (tmp == 0 && zeros == 0) continue;
         zeros = 1;
-        if (tmp > 0xA) append(str, tmp - 0xA + 'a');
+        if (tmp >= 0xA) append(str, tmp - 0xA + 'a');
         else append(str, tmp + '0');
     }
 

--- a/23-fixes/libc/string.c
+++ b/23-fixes/libc/string.c
@@ -29,7 +29,7 @@ void hex_to_ascii(int n, char str[]) {
         tmp = (n >> i) & 0xF;
         if (tmp == 0 && zeros == 0) continue;
         zeros = 1;
-        if (tmp > 0xA) append(str, tmp - 0xA + 'a');
+        if (tmp >= 0xA) append(str, tmp - 0xA + 'a');
         else append(str, tmp + '0');
     }
 


### PR DESCRIPTION
The 'a'/'A' character in hex values was not being converted properly, and instead printed a colon. This fixes that.