### PR TITLE
Fix bad/non-existent castings

### DIFF
--- a/16-video-driver/drivers/screen.c
+++ b/16-video-driver/drivers/screen.c
@@ -107,7 +107,7 @@ void set_cursor_offset(int offset) {
 void clear_screen() {
     int screen_size = MAX_COLS * MAX_ROWS;
     int i;
-    char *screen = VIDEO_ADDRESS;
+    unsigned char *screen = (unsigned char *)VIDEO_ADDRESS;
 
     for (i = 0; i < screen_size; i++) {
         screen[i*2] = ' ';

--- a/17-video-scroll/drivers/screen.c
+++ b/17-video-scroll/drivers/screen.c
@@ -85,12 +85,12 @@ int print_char(char c, int col, int row, char attr) {
     if (offset >= MAX_ROWS * MAX_COLS * 2) {
         int i;
         for (i = 1; i < MAX_ROWS; i++) 
-            memory_copy(get_offset(0, i) + VIDEO_ADDRESS,
-                        get_offset(0, i-1) + VIDEO_ADDRESS,
+            memory_copy((char *)get_offset(0, i) + VIDEO_ADDRESS,
+                        (char *)get_offset(0, i-1) + VIDEO_ADDRESS,
                         MAX_COLS * 2);
 
         /* Blank last line */
-        char *last_line = get_offset(0, MAX_ROWS-1) + VIDEO_ADDRESS;
+        char *last_line = (char *)get_offset(0, MAX_ROWS-1) + VIDEO_ADDRESS;
         for (i = 0; i < MAX_COLS * 2; i++) last_line[i] = 0;
 
         offset -= 2 * MAX_COLS;
@@ -124,7 +124,7 @@ void set_cursor_offset(int offset) {
 void clear_screen() {
     int screen_size = MAX_COLS * MAX_ROWS;
     int i;
-    char *screen = VIDEO_ADDRESS;
+    unsigned char *screen = (unsigned char *)VIDEO_ADDRESS;
 
     for (i = 0; i < screen_size; i++) {
         screen[i*2] = ' ';

--- a/18-interrupts/drivers/screen.c
+++ b/18-interrupts/drivers/screen.c
@@ -85,8 +85,8 @@ int print_char(char c, int col, int row, char attr) {
     if (offset >= MAX_ROWS * MAX_COLS * 2) {
         int i;
         for (i = 1; i < MAX_ROWS; i++) 
-            memory_copy(get_offset(0, i) + VIDEO_ADDRESS,
-                        get_offset(0, i-1) + VIDEO_ADDRESS,
+            memory_copy((char *)get_offset(0, i) + VIDEO_ADDRESS,
+                        (char *)get_offset(0, i-1) + VIDEO_ADDRESS,
                         MAX_COLS * 2);
 
         /* Blank last line */
@@ -124,7 +124,7 @@ void set_cursor_offset(int offset) {
 void clear_screen() {
     int screen_size = MAX_COLS * MAX_ROWS;
     int i;
-    char *screen = VIDEO_ADDRESS;
+    unsigned char *screen = (unsigned char *)VIDEO_ADDRESS;
 
     for (i = 0; i < screen_size; i++) {
         screen[i*2] = ' ';

--- a/20-interrupts-timer/drivers/screen.c
+++ b/20-interrupts-timer/drivers/screen.c
@@ -84,8 +84,8 @@ int print_char(char c, int col, int row, char attr) {
     if (offset >= MAX_ROWS * MAX_COLS * 2) {
         int i;
         for (i = 1; i < MAX_ROWS; i++) 
-            memory_copy(get_offset(0, i) + VIDEO_ADDRESS,
-                        get_offset(0, i-1) + VIDEO_ADDRESS,
+            memory_copy((char *)get_offset(0, i) + VIDEO_ADDRESS,
+                        (char *)get_offset(0, i-1) + VIDEO_ADDRESS,
                         MAX_COLS * 2);
 
         /* Blank last line */
@@ -123,7 +123,7 @@ void set_cursor_offset(int offset) {
 void clear_screen() {
     int screen_size = MAX_COLS * MAX_ROWS;
     int i;
-    char *screen = VIDEO_ADDRESS;
+    unsigned char *screen = (unsigned char *)VIDEO_ADDRESS;
 
     for (i = 0; i < screen_size; i++) {
         screen[i*2] = ' ';


### PR DESCRIPTION
Warnings can occur in GCC if those casts are not present.