### PR TITLE
Lesson 22 - hex_to_ascii bug

### DIFF
--- a/22-malloc/libc/string.c
+++ b/22-malloc/libc/string.c
@@ -29,7 +29,7 @@ void hex_to_ascii(int n, char str[]) {
         tmp = (n >> i) & 0xF;
         if (tmp == 0 && zeros == 0) continue;
         zeros = 1;
-        if (tmp > 0xA) append(str, tmp - 0xA + 'a');
+        if (tmp >= 0xA) append(str, tmp - 0xA + 'a');
         else append(str, tmp + '0');
     }
 


### PR DESCRIPTION
Correction to hex_to_ascii, `tmp > 0xA` should be `tmp >= 0xA`

This was causing 0x:000 to appear instead of 0xa000.

Thanks for the great tutorial!