### PR TITLE
add '-S' to qemu debug to prevent starting

### DIFF
--- a/14-checkpoint/Makefile
+++ b/14-checkpoint/Makefile
@@ -27,7 +27,7 @@ run: os-image.bin
 
 # Open the connection to qemu and load our kernel-object file with symbols
 debug: os-image.bin kernel.elf
-	qemu-system-i386 -s -fda os-image.bin &
+	qemu-system-i386 -s -S -fda os-image.bin &
 	${GDB} -ex "target remote localhost:1234" -ex "symbol-file kernel.elf"
 
 # Generic rules for wildcards


### PR DESCRIPTION
Pretty sure I'm just fixing a typo here, since the readme mentions `break main`, `continue`. etc.

> Starting QEMU with the -S command-line switch prevents the CPU from starting. This gives time for the debugger to connect and allows to start debugging from the very beginning, even the early platform firmware.
>
> To start execution, you must send QEMU the "continue" command, either via the debugger or the monitor console.
>
> https://en.wikibooks.org/wiki/QEMU/Debugging_with_QEMU#Launching_QEMU_from_GDB