### PR TITLE
cr0 "32bit bit" -> "protected mode" bit

### DIFF
--- a/10-32bit-enter/32bit-switch.asm
+++ b/10-32bit-enter/32bit-switch.asm
@@ -3,7 +3,7 @@ switch_to_pm:
     cli ; 1. disable interrupts
     lgdt [gdt_descriptor] ; 2. load the GDT descriptor
     mov eax, cr0
-    or eax, 0x1 ; 3. set 32-bit mode bit in cr0
+    or eax, 0x1 ; 3. set protected mode bit in cr0
     mov cr0, eax
     jmp CODE_SEG:init_pm ; 4. far jump by using a different segment
 


### PR DESCRIPTION
This comment seems misleading to me, bit 0 of the `cr0` register enables protected mode, and that is its official name, is there a reason why it says "32 bit"?
Sources:
- [Intel manual](https://www.intel.com/content/dam/www/public/us/en/documents/manuals/64-ia-32-architectures-software-developer-vol-3a-part-1-manual.pdf) page 78
- https://wiki.osdev.org/CPU_Registers_x86#CR0