### PR TITLE
Fixed typo in README.md

### DIFF
--- a/12-kernel-c/README.md
+++ b/12-kernel-c/README.md
@@ -60,6 +60,6 @@ I encourage you to write more small programs, which feature:
 - Pointers `pointers.c`
 
 Then compile and disassemble them, and examine the resulting machine code. Follow
-the os-guide.pdf for explanations. Try to answer this question: why does the
+the os-dev.pdf for explanations. Try to answer this question: why does the
 disassemblement of `pointers.c` not resemble what you would expect? Where is
 the ASCII `0x48656c6c6f` for "Hello"?


### PR DESCRIPTION
'os-guide.pdf' should be 'os-dev.pdf', i think.
https://github.com/cfenollosa/os-tutorial/search?q=os-dev.pdf&unscoped_q=os-dev.pdf