### PR TITLE
Lesson 18 - Multiple Definition Error

### DIFF
--- a/18-interrupts/cpu/idt.c
+++ b/18-interrupts/cpu/idt.c
@@ -1,6 +1,9 @@
 #include "idt.h"
 #include "../kernel/util.h"
 
+idt_gate_t idt[IDT_ENTRIES];
+idt_register_t idt_reg;
+
 void set_idt_gate(int n, u32 handler) {
     idt[n].low_offset = low_16(handler);
     idt[n].sel = KERNEL_CS;

--- a/18-interrupts/cpu/idt.h
+++ b/18-interrupts/cpu/idt.h
@@ -28,9 +28,8 @@ typedef struct {
 } __attribute__((packed)) idt_register_t;
 
 #define IDT_ENTRIES 256
-idt_gate_t idt[IDT_ENTRIES];
-idt_register_t idt_reg;
-
+extern idt_gate_t idt[IDT_ENTRIES];
+extern idt_register_t idt_reg;
 
 /* Functions implemented in idt.c */
 void set_idt_gate(int n, u32 handler);


### PR DESCRIPTION
Owing to the fact that `idt` and `idt_reg` were not declared as `extern` variables in `idt.h`, I encountered a couple of Multiple Definition Errors. I have made the same changes myself.