### PR TITLE
remove idt & idt_reg

### DIFF
--- a/18-interrupts/cpu/idt.h
+++ b/18-interrupts/cpu/idt.h
@@ -27,10 +27,6 @@ typedef struct {
     u32 base;
 } __attribute__((packed)) idt_register_t;
 
-#define IDT_ENTRIES 256
-idt_gate_t idt[IDT_ENTRIES];
-idt_register_t idt_reg;
-
 
 /* Functions implemented in idt.c */
 void set_idt_gate(int n, u32 handler);


### PR DESCRIPTION
 "idt.h" included by idt.c and kernel.c, which will cause link failed. so move the definition of idt to idt.c to avoid the failure below.

ld: cpu/idt.o:(.bss+0x0): multiple definition of `idt'; kernel/kernel.o:(.bss+0x0): first defined here
ld: cpu/idt.o:(.bss+0x800): multiple definition of `idt_reg'; kernel/kernel.o:(.bss+0x800): first defined here
ld: cpu/isr.o:(.bss+0x0): multiple definition of `idt'; kernel/kernel.o:(.bss+0x0): first defined here
ld: cpu/isr.o:(.bss+0x800): multiple definition of `idt_reg'; kernel/kernel.o:(.bss+0x800): first defined here