### PR TITLE
fix the error that print 'S' continuously in lesson 10

### DIFF
--- a/05-bootsector-functions-strings/boot_sect_print.asm
+++ b/05-bootsector-functions-strings/boot_sect_print.asm
@@ -1,3 +1,4 @@
+[bits 16]
 print:
     pusha
 


### PR DESCRIPTION
When running the 32bit-main.asm, in my environment(nasm v2.13.02, qemu v2.11.1), it will print 'S' continuously.
In my code, the only difference is the order of include. As follows.

'''
%include "../08-32bit-print/32bit-print.asm"
%include "32bit-switch.asm"
%include "../09-32bit-gdt/32bit-gdt.asm"
%include "../05-bootsector-functions-strings/boot_sect_print.asm"
'''