### PR TITLE
Fixed typo regarding indirect addressing

### DIFF
--- a/03-bootsector-memory/boot_sect_memory.asm
+++ b/03-bootsector-memory/boot_sect_memory.asm
@@ -9,7 +9,7 @@ mov al, the_secret
 int 0x10
 
 ; attempt 2
-; It tries to print the memory address of 'the_secret' which is the correct approach.
+; It tries to print the data at the memory address of 'the_secret' which is the correct approach.
 ; However, BIOS places our bootsector binary at address 0x7c00
 ; so we need to add that padding beforehand. We'll do that in attempt 3
 mov al, "2"


### PR DESCRIPTION
The comment previously stated that attempt 2 was "printing the memory address...", but it is meant to say "printing the data at the memory address..." since it was indirectly addressed using [the_secret]