### PR TITLE
Moved idt and idt reg from idt.h to idt.c

### DIFF
--- a/18-interrupts/cpu/idt.h
+++ b/18-interrupts/cpu/idt.h
@@ -28,8 +28,6 @@ typedef struct {
 } __attribute__((packed)) idt_register_t;
 
 #define IDT_ENTRIES 256
-idt_gate_t idt[IDT_ENTRIES];
-idt_register_t idt_reg;
 
 
 /* Functions implemented in idt.c */


### PR DESCRIPTION
Moved idt and idt reg from idt.h to idt.c to fix the make error: multiple definitions of ...