### PR TITLE
01-bootsector-barebones: append hexdump analysis

### DIFF
--- a/01-bootsector-barebones/README.md
+++ b/01-bootsector-barebones/README.md
@@ -50,6 +50,7 @@ To compile:
 `nasm -f bin boot_sect_simple.asm -o boot_sect_simple.bin`
 
 > OSX warning: if this drops an error, read chapter 00 again
+> Use `hexdump boot_sect_simple.bin` to show the hexadecimal dump of the compiled binary
 
 I know you're anxious to try it out (I am!), so let's do it:
 


### PR DESCRIPTION
Appending a tip to suggest readers could verify their compiled binary if they are interested in.

Some more topic may be worthy of discussing. I hope they are not too bike-shedding:
- Is appending this kind of information too much detailed? If yes, feel free to reject my pull request.
- Should the tutorial explain a bit the output of `hexdump`
- Should the tutorial also suggest use the other tool like `od` to dump the hexadecimal information?