### PR TITLE
Added left shift caps and fixed backspace issue

### DIFF
--- a/21-shell/drivers/keyboard.c
+++ b/21-shell/drivers/keyboard.c
@@ -47,7 +47,7 @@ static void keyboard_callback(registers_t regs) {
     } else {
         char letter = sc_ascii[(int)scancode];
         /* Remember that kprint only accepts char[] */
-        if (caps == 1) {letter = chrupper(letter)};
+        if (caps == 1) {letter = chrupper(letter);};
         char str[2] = {letter, '\0'};
         append(key_buffer, letter);
         kprint(str);

--- a/21-shell/drivers/keyboard.c
+++ b/21-shell/drivers/keyboard.c
@@ -10,7 +10,7 @@
 #define ENTER 0x1C
 #define LSHIFT_DOWN 0x2a
 #define LSHIFT_UP 0xaa
-int caps = 0;
+u8 caps = 0;
 static char key_buffer[256];
 
 #define SC_MAX 57

--- a/21-shell/drivers/keyboard.c
+++ b/21-shell/drivers/keyboard.c
@@ -8,7 +8,9 @@
 
 #define BACKSPACE 0x0E
 #define ENTER 0x1C
-
+#define LSHIFT_DOWN 0x2a
+#define LSHIFT_UP 0xaa
+int caps = 0;
 static char key_buffer[256];
 
 #define SC_MAX 57
@@ -19,26 +21,33 @@ const char *sc_name[] = { "ERROR", "Esc", "1", "2", "3", "4", "5", "6",
         "LShift", "\\", "Z", "X", "C", "V", "B", "N", "M", ",", ".", 
         "/", "RShift", "Keypad *", "LAlt", "Spacebar"};
 const char sc_ascii[] = { '?', '?', '1', '2', '3', '4', '5', '6',     
-    '7', '8', '9', '0', '-', '=', '?', '?', 'Q', 'W', 'E', 'R', 'T', 'Y', 
-        'U', 'I', 'O', 'P', '[', ']', '?', '?', 'A', 'S', 'D', 'F', 'G', 
-        'H', 'J', 'K', 'L', ';', '\'', '`', '?', '\\', 'Z', 'X', 'C', 'V', 
-        'B', 'N', 'M', ',', '.', '/', '?', '?', '?', ' '};
+    '7', '8', '9', '0', '-', '=', '?', '?', 'q', 'w', 'e', 'r', 't', 'y', 
+        'u', 'i', 'o', 'p', '[', ']', '?', '?', 'a', 's', 'd', 'f', 'g', 
+        'h', 'j', 'k', 'l', ';', '\'', '`', '?', '\\', 'z', 'x', 'c', 'v', 
+        'b', 'n', 'm', ',', '.', '/', '?', '?', '?', ' '};
 
 static void keyboard_callback(registers_t regs) {
     /* The PIC leaves us the scancode in port 0x60 */
     u8 scancode = port_byte_in(0x60);
-    
+    if (scancode == LSHIFT_UP){caps=0;}
     if (scancode > SC_MAX) return;
     if (scancode == BACKSPACE) {
-        backspace(key_buffer);
-        kprint_backspace();
+        if (key_buffer[0] != '\0') {
+            backspace(key_buffer);
+            kprint_backspace();
+        }
     } else if (scancode == ENTER) {
         kprint("\n");
         user_input(key_buffer); /* kernel-controlled function */
         key_buffer[0] = '\0';
+    }else if (scancode == LSHIFT_DOWN) {
+        if (caps == 0) {
+            caps++;
+        }
     } else {
         char letter = sc_ascii[(int)scancode];
         /* Remember that kprint only accepts char[] */
+        if (caps == 1) {letter = chrupper(letter)};
         char str[2] = {letter, '\0'};
         append(key_buffer, letter);
         kprint(str);

--- a/21-shell/libc/string.c
+++ b/21-shell/libc/string.c
@@ -33,6 +33,10 @@ int strlen(char s[]) {
     while (s[i] != '\0') ++i;
     return i;
 }
+char chrupper(char chr) {
+  if((chr>96) && (chr<123)) chr ^=0x20;
+  return chr;
+}
 
 void append(char s[], char n) {
     int len = strlen(s);

--- a/21-shell/libc/string.h
+++ b/21-shell/libc/string.h
@@ -7,5 +7,6 @@ int strlen(char s[]);
 void backspace(char s[]);
 void append(char s[], char n);
 int strcmp(char s1[], char s2[]);
+char chrupper(char chr);
 
 #endif

--- a/22-malloc/drivers/keyboard.c
+++ b/22-malloc/drivers/keyboard.c
@@ -10,7 +10,7 @@
 #define ENTER 0x1C
 #define LSHIFT_DOWN 0x2a
 #define LSHIFT_UP 0xaa
-int caps = 0;
+u8 caps = 0;
 static char key_buffer[256];
 
 #define SC_MAX 57

--- a/22-malloc/drivers/keyboard.c
+++ b/22-malloc/drivers/keyboard.c
@@ -8,7 +8,9 @@
 
 #define BACKSPACE 0x0E
 #define ENTER 0x1C
-
+#define LSHIFT_DOWN 0x2a
+#define LSHIFT_UP 0xaa
+int caps = 0;
 static char key_buffer[256];
 
 #define SC_MAX 57
@@ -19,26 +21,33 @@ const char *sc_name[] = { "ERROR", "Esc", "1", "2", "3", "4", "5", "6",
         "LShift", "\\", "Z", "X", "C", "V", "B", "N", "M", ",", ".", 
         "/", "RShift", "Keypad *", "LAlt", "Spacebar"};
 const char sc_ascii[] = { '?', '?', '1', '2', '3', '4', '5', '6',     
-    '7', '8', '9', '0', '-', '=', '?', '?', 'Q', 'W', 'E', 'R', 'T', 'Y', 
-        'U', 'I', 'O', 'P', '[', ']', '?', '?', 'A', 'S', 'D', 'F', 'G', 
-        'H', 'J', 'K', 'L', ';', '\'', '`', '?', '\\', 'Z', 'X', 'C', 'V', 
-        'B', 'N', 'M', ',', '.', '/', '?', '?', '?', ' '};
+    '7', '8', '9', '0', '-', '=', '?', '?', 'q', 'w', 'e', 'r', 't', 'y', 
+        'u', 'i', 'o', 'p', '[', ']', '?', '?', 'a', 's', 'd', 'f', 'g', 
+        'h', 'j', 'k', 'l', ';', '\'', '`', '?', '\\', 'z', 'x', 'c', 'v', 
+        'b', 'n', 'm', ',', '.', '/', '?', '?', '?', ' '};
 
 static void keyboard_callback(registers_t regs) {
     /* The PIC leaves us the scancode in port 0x60 */
     u8 scancode = port_byte_in(0x60);
-    
+    if (scancode == LSHIFT_UP){caps=0;}
     if (scancode > SC_MAX) return;
     if (scancode == BACKSPACE) {
-        backspace(key_buffer);
-        kprint_backspace();
+        if (key_buffer[0] != '\0') {
+            backspace(key_buffer);
+            kprint_backspace();
+        }
     } else if (scancode == ENTER) {
         kprint("\n");
         user_input(key_buffer); /* kernel-controlled function */
         key_buffer[0] = '\0';
+    }else if (scancode == LSHIFT_DOWN) {
+        if (caps == 0) {
+            caps++;
+        }
     } else {
         char letter = sc_ascii[(int)scancode];
         /* Remember that kprint only accepts char[] */
+        if (caps == 1) {letter = chrupper(letter);};
         char str[2] = {letter, '\0'};
         append(key_buffer, letter);
         kprint(str);

--- a/22-malloc/libc/string.c
+++ b/22-malloc/libc/string.c
@@ -75,3 +75,8 @@ int strcmp(char s1[], char s2[]) {
     }
     return s1[i] - s2[i];
 }
+
+char chrupper(char chr) {
+  if((chr>96) && (chr<123)) chr ^=0x20;
+  return chr;
+}

--- a/22-malloc/libc/string.h
+++ b/22-malloc/libc/string.h
@@ -8,5 +8,6 @@ int strlen(char s[]);
 void backspace(char s[]);
 void append(char s[], char n);
 int strcmp(char s1[], char s2[]);
+char chrupper(char chr);
 
 #endif


### PR DESCRIPTION
Added a function in the string library to make characters uppercase, chrupper.
Now detects left shift down and left shift up, providing uppercase and lowercase characters.
Fixed backspace by checking key_buffer[0] == '\0'.